### PR TITLE
PaypalIPN.php - Added missing "User-Agent" string

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="SilverStripe">
+    <description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
+
+    <file>src</file>
+
+    <!-- base rules are PSR-2 -->
+    <rule ref="PSR2">
+        <!-- Current exclusions -->
+        <exclude name="PSR1.Methods.CamelCapsMethodName"/>
+        <exclude name="PSR2.Classes.PropertyDeclaration.Underscore"/>
+        <exclude name="Squiz.Classes.ValidClassName.NotCamelCaps"/>
+        <exclude name="Generic.Files.LineLength.TooLong"/>
+        <exclude name="PSR1.Files.SideEffects.FoundWithSymbols"/>
+    </rule>
+
+    <!-- use short array syntax -->
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+</ruleset>

--- a/src/PaypalIPN.php
+++ b/src/PaypalIPN.php
@@ -22,7 +22,6 @@ class PaypalIPN
     /** Response from PayPal indicating validation failed */
     const INVALID = 'INVALID';
 
-
     /**
      * Sets the IPN verification to sandbox mode (for use when testing,
      * should not be enabled in production).
@@ -43,7 +42,6 @@ class PaypalIPN
         $this->useLocalCerts = false;
     }
 
-
     /**
      * Determine endpoint to post the verification data to.
      * @return string
@@ -57,7 +55,6 @@ class PaypalIPN
         }
     }
 
-
     /**
      * Verification Function
      * Sends the incoming post data back to PayPal using the cURL library.
@@ -65,7 +62,7 @@ class PaypalIPN
      * @return bool
      * @throws Exception
      */
-    function verifyIPN()
+    public function verifyIPN()
     {
         if (!count($_POST)) {
             throw new Exception("Missing POST Data");
@@ -86,16 +83,8 @@ class PaypalIPN
             }
         }
         $req = 'cmd=_notify-validate';
-        $get_magic_quotes_exists = false;
-        if (function_exists('get_magic_quotes_gpc')) {
-            $get_magic_quotes_exists = true;
-        }
         foreach ($myPost as $key => $value) {
-            if ($get_magic_quotes_exists == true && get_magic_quotes_gpc() == 1) {
-                $value = urlencode(stripslashes($value));
-            } else {
-                $value = urlencode($value);
-            }
+            $value = urlencode($value);
             $req .= "&$key=$value";
         }
 
@@ -112,10 +101,10 @@ class PaypalIPN
         }
         curl_setopt($ch, CURLOPT_FORBID_REUSE, 1);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 30);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
             'User-Agent: PHP-IPN-Verification-Script',
             'Connection: Close',
-        ));
+        ]);
         $res = curl_exec($ch);
         $info = curl_getinfo($ch);
         $http_code = $info['http_code'];
@@ -138,4 +127,3 @@ class PaypalIPN
         }
     }
 }
-

--- a/src/PaypalIPN.php
+++ b/src/PaypalIPN.php
@@ -112,7 +112,10 @@ class PaypalIPN
         }
         curl_setopt($ch, CURLOPT_FORBID_REUSE, 1);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 30);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, ['Connection: Close']);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+            'User-Agent: PHP-IPN-Verification-Script',
+            'Connection: Close',
+        ));
         $res = curl_exec($ch);
         $info = curl_getinfo($ch);
         $http_code = $info['http_code'];


### PR DESCRIPTION
### Description
I found recently that my sandbox transactions were all returning INVALID for some reason. After hours of banging my head against the wall checking my code, IPN History logs, Listener logs, etc. I found the following note in the Paypal Documentation

> Please ensure you provide a User-Agent header value that describes your IPN listener, such as, PHP-IPN-VerificationScript. For more information, see the [User-Agent specification](https://tools.ietf.org/html/rfc7231#section-5.5.3).

Ans after comparing this listener code to the official code found in the IPN Example code repository, I realized that this script was missing that user agent string. So I added it, an boom, the sandbox IPN came back as valid.

### Changes
+ Added a "PHP-IPN-Verification-Script" User-Agent string to fix issues with Sandbox system