### PR TITLE
fix #4 - get_magic_quotes_gpc() deprecated

### DIFF
--- a/src/PaypalIPN.php
+++ b/src/PaypalIPN.php
@@ -86,16 +86,8 @@ class PaypalIPN
             }
         }
         $req = 'cmd=_notify-validate';
-        $get_magic_quotes_exists = false;
-        if (function_exists('get_magic_quotes_gpc')) {
-            $get_magic_quotes_exists = true;
-        }
         foreach ($myPost as $key => $value) {
-            if ($get_magic_quotes_exists == true && get_magic_quotes_gpc() == 1) {
-                $value = urlencode(stripslashes($value));
-            } else {
-                $value = urlencode($value);
-            }
+            $value = urlencode($value);
             $req .= "&$key=$value";
         }
 


### PR DESCRIPTION
The magic quotes feature is completely removed as of PHP 8.0. Since it is impossible for it to be turned on, we do not need to stripslashes() at all now.

Fixes #4 

Allows this library to be used on PHP 8.0+ servers without throwing an error.