### PR TITLE
remove slash in "use \Exception;"

### DIFF
--- a/src/PaypalIPN.php
+++ b/src/PaypalIPN.php
@@ -2,7 +2,7 @@
 
 namespace overint;
 
-use \Exception;
+use Exception;
 
 class PaypalIPN
 {


### PR DESCRIPTION
I don't think the slash is needed.

Untested.